### PR TITLE
Fix return-to-browser flow: back button, context, page state, macOS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,23 +119,32 @@ task fmt-fix
 
 ### Development Setup with KOReader
 
-For development testing, create a symlink to the built plugin:
+For development testing, create a symlink to the built plugin.
 
 #### macOS
+
+KOReader on macOS is a self-contained `.app` bundle. It looks for plugins inside
+the bundle at `/Applications/KOReader.app/Contents/koreader/plugins/`, **not** in
+`~/.config/koreader/`. Its writable data directory is `~/Library/Application
+Support/koreader/` (where settings, cache, history, and logs live).
 
 ```bash
 # Build the plugin first
 task build
 
-# Create symlink to KOReader plugins directory
-ln -s /path/to/miniflux.koplugin/dist/miniflux.koplugin ~/.config/koreader/plugins/miniflux.koplugin
+# Symlink the built plugin into KOReader's bundled plugins directory
+ln -snf "$(pwd)/dist/miniflux.koplugin" \
+    /Applications/KOReader.app/Contents/koreader/plugins/miniflux.koplugin
 
-# Run KOReader with debug logging
-/System/Volumes/Data/Applications/KOReader.app/Contents/MacOS/koreader -d
+# Run KOReader with debug logging (logs go to stdout)
+/Applications/KOReader.app/Contents/MacOS/koreader -d
 
-# Filter logs for Miniflux-specific messages
-/System/Volumes/Data/Applications/KOReader.app/Contents/MacOS/koreader -d 2>&1 | grep -E "Miniflux"
+# Or filter logs for Miniflux-specific messages
+/Applications/KOReader.app/Contents/MacOS/koreader -d 2>&1 | grep -E "Miniflux"
 ```
+
+Re-run `task build` after each code change. The symlink picks up the new files
+automatically; just restart KOReader (plugins are scanned at startup).
 
 ## Contributing
 

--- a/src/features/browser/miniflux_browser.lua
+++ b/src/features/browser/miniflux_browser.lua
@@ -326,6 +326,60 @@ function MinifluxBrowser:openItem(entry_data, context)
     })
 end
 
+---Open the browser at a saved navigation context, seeding the back stack so
+---the user can navigate back through the natural hierarchy (e.g. feed_entries
+---→ feeds → main). When called with no context, opens the main view.
+---@param context? MinifluxContext Saved browser context
+function MinifluxBrowser:openContext(context)
+    -- We are entering the browser from outside (the reader). Reset the back
+    -- stack so we synthesize a fresh hierarchy instead of stacking on top of
+    -- whatever paths happened to be there before the entry was opened.
+    self.paths = {}
+
+    if not context or not context.type then
+        self:open()
+        return
+    end
+
+    local view_name
+    local nav_context
+
+    if context.type == 'feed' then
+        view_name = 'feed_entries'
+        nav_context = { feed_id = context.id }
+        table.insert(self.paths, { from = 'main', to = 'feeds', page_state = 1 })
+        table.insert(self.paths, {
+            from = 'feeds',
+            to = 'feed_entries',
+            page_state = 1,
+            context = nav_context,
+        })
+    elseif context.type == 'category' then
+        view_name = 'category_entries'
+        nav_context = { category_id = context.id }
+        table.insert(self.paths, { from = 'main', to = 'categories', page_state = 1 })
+        table.insert(self.paths, {
+            from = 'categories',
+            to = 'category_entries',
+            page_state = 1,
+            context = nav_context,
+        })
+    elseif context.type == 'unread' then
+        view_name = 'unread_entries'
+        table.insert(self.paths, { from = 'main', to = 'unread_entries', page_state = 1 })
+    elseif context.type == 'local' then
+        view_name = 'local_entries'
+        table.insert(self.paths, { from = 'main', to = 'local_entries', page_state = 1 })
+    else
+        view_name = 'main'
+    end
+
+    self:navigate({
+        view_name = view_name,
+        context = nav_context,
+    })
+end
+
 ---Get Miniflux-specific route handlers (implements Browser:getRouteHandlers)
 ---@param nav_config RouteConfig<MinifluxNavigationContext> Navigation configuration
 ---@return table<string, function> Route handlers lookup table

--- a/src/features/browser/miniflux_browser.lua
+++ b/src/features/browser/miniflux_browser.lua
@@ -309,7 +309,7 @@ end
 
 ---Open an entry with optional navigation context (implements Browser:openItem)
 ---@param entry_data table Entry data from API
----@param context? {type: "feed"|"category", id: number} Navigation context (nil = global)
+---@param context? MinifluxContext Navigation context (nil = global)
 function MinifluxBrowser:openItem(entry_data, context)
     logger.dbg(
         '[Miniflux:Browser] Opening entry:',
@@ -317,7 +317,11 @@ function MinifluxBrowser:openItem(entry_data, context)
         'with context:',
         context and context.type or 'global'
     )
-    -- Use workflow directly for download-if-needed and open
+    -- Capture the user's current scroll position so "Return to Miniflux"
+    -- can restore the same page in the list instead of jumping to page 1.
+    if context then
+        context.page_state = self:getCurrentItemNumber()
+    end
     local EntryWorkflow = require('features/browser/download/download_entry')
     EntryWorkflow.execute({
         entry_data = entry_data,
@@ -344,6 +348,10 @@ function MinifluxBrowser:openContext(context)
     local view_name
     local nav_context
 
+    -- page_state is per-view: in self.paths it stores where the user was on
+    -- the *previous* (from) view (so Back lands at item 1 of feeds/categories,
+    -- which is fine). For the destination view we pass page_state directly to
+    -- navigate() so the entries list scrolls to the entry the user just read.
     if context.type == 'feed' then
         view_name = 'feed_entries'
         nav_context = { feed_id = context.id }
@@ -377,6 +385,7 @@ function MinifluxBrowser:openContext(context)
     self:navigate({
         view_name = view_name,
         context = nav_context,
+        page_state = context.page_state,
     })
 end
 

--- a/src/features/reader/modules/miniflux_end_of_book.lua
+++ b/src/features/reader/modules/miniflux_end_of_book.lua
@@ -191,10 +191,14 @@ function MinifluxEndOfBook:showDialog(entry_info)
         },
         {
             {
-                text = _('⌂ Miniflux folder'),
+                text = _('⌂ Return to Miniflux'),
                 callback = function()
                     UIManager:close(dialog)
-                    EntryPaths.openMinifluxFolder()
+                    local ReaderUI = require('apps/reader/readerui')
+                    if ReaderUI.instance then
+                        ReaderUI.instance:onClose()
+                    end
+                    self:returnToBrowser()
                 end,
             },
             {

--- a/src/features/reader/modules/miniflux_end_of_book.lua
+++ b/src/features/reader/modules/miniflux_end_of_book.lua
@@ -249,45 +249,16 @@ function MinifluxEndOfBook:showDialog(entry_info)
     return dialog
 end
 
----Return to the browser view where the user was before opening this entry
+---Return to the browser view where the user was before opening this entry.
+---Routing and back-stack seeding live in MinifluxBrowser:openContext so the
+---back button works as expected after the user lands on the saved view.
+---@return nil
 function MinifluxEndOfBook:returnToBrowser()
     if not self.miniflux or not self.miniflux.browser then
         return
     end
 
-    -- Get the saved browser context
-    local context = self.miniflux:getBrowserContext()
-
-    if not context or not context.type then
-        -- No context saved, default to main view
-        self.miniflux.browser:open()
-        return
-    end
-
-    -- Map context type to view name and navigation config
-    local view_name
-    local nav_context
-
-    if context.type == 'feed' then
-        view_name = 'feed_entries'
-        nav_context = { feed_id = context.id }
-    elseif context.type == 'category' then
-        view_name = 'category_entries'
-        nav_context = { category_id = context.id }
-    elseif context.type == 'unread' then
-        view_name = 'unread_entries'
-    elseif context.type == 'local' then
-        view_name = 'local_entries'
-    else
-        -- Default to main for 'global' or unknown types
-        view_name = 'main'
-    end
-
-    -- Navigate to the saved view with context
-    self.miniflux.browser:navigate({
-        view_name = view_name,
-        context = nav_context,
-    })
+    self.miniflux.browser:openContext(self.miniflux:getBrowserContext())
 end
 
 ---Cleanup method - revert the wrapped method

--- a/src/features/reader/services/open_entry.lua
+++ b/src/features/reader/services/open_entry.lua
@@ -11,9 +11,10 @@ Future improvements planned:
 --]]
 
 local MinifluxEvent = require('shared/event')
+local BrowserContext = require('shared/browser_context')
 
 ---@class MinifluxContext
----@field type string Context type ("feed", "category", "global", "local")
+---@field type string Context type ("feed", "category", "global", "local", "unread")
 ---@field id? number Feed or category ID
 ---@field ordered_entries? table[] Ordered entries for navigation
 
@@ -34,6 +35,11 @@ function EntryReader.openEntry(file_path, opts)
     MinifluxEvent:broadcastBrowserCloseRequest({ reason = 'entry_opening' })
 
     if context then
+        -- Persist the context in the module-scoped store BEFORE broadcasting.
+        -- Plugin instances may not be registered with UIManager during the
+        -- transition into the reader, so the broadcast handler is unreliable
+        -- as the sole writer (see #65 follow-up).
+        BrowserContext.set(context)
         MinifluxEvent:broadcastMinifluxBrowserContextChange({ context = context })
     end
 

--- a/src/features/reader/services/open_entry.lua
+++ b/src/features/reader/services/open_entry.lua
@@ -17,6 +17,7 @@ local BrowserContext = require('shared/browser_context')
 ---@field type string Context type ("feed", "category", "global", "local", "unread")
 ---@field id? number Feed or category ID
 ---@field ordered_entries? table[] Ordered entries for navigation
+---@field page_state? number Item number the user was focused on when they opened the entry, used to restore scroll position when returning to the browser
 
 ---@class EntryReader
 local EntryReader = {}

--- a/src/main.lua
+++ b/src/main.lua
@@ -23,6 +23,7 @@ local ReaderEntryService = require('features/reader/services/entry_service')
 local QueueService = require('features/sync/services/queue_service')
 local SyncService = require('features/sync/services/sync_service')
 local HTTPCacheAdapter = require('shared/http_cache_adapter')
+local BrowserContext = require('shared/browser_context')
 
 ---@class Miniflux : WidgetContainer
 ---@field name string Plugin name identifier
@@ -52,7 +53,6 @@ local Miniflux = WidgetContainer:extend({
     subprocesses_pids = {},
     subprocesses_collector = nil,
     subprocesses_collect_interval = 10,
-    browser_context = nil,
     download_dir = ('%s/%s/'):format(DataStorage:getFullDataDir(), 'miniflux'),
 })
 
@@ -340,13 +340,16 @@ function Miniflux:onCloseWidget()
 end
 
 function Miniflux:onMinifluxBrowserContextChange(payload)
+    -- Canonical state lives in the BrowserContext module (set by EntryReader
+    -- before the broadcast fires) so it survives plugin teardown. This
+    -- handler is kept for any future listeners that want a real event.
     logger.info('[Miniflux:browser_context] Browser context changed:', payload.context)
-    Miniflux.browser_context = payload.context
 end
 
 function Miniflux:getBrowserContext()
-    logger.info('[Miniflux:browser_context] Getting browser context:', Miniflux.browser_context)
-    return Miniflux.browser_context
+    local context = BrowserContext.get()
+    logger.info('[Miniflux:browser_context] Getting browser context:', context)
+    return context
 end
 
 return Miniflux

--- a/src/shared/browser_context.lua
+++ b/src/shared/browser_context.lua
@@ -1,0 +1,31 @@
+--[[--
+**Browser Context Store**
+
+Holds the most recent browser navigation context (feed, category, unread,
+local, ...) at module scope so it survives plugin instance teardown.
+
+Plugin instances come and go: opening an entry tears down the file-manager
+Miniflux plugin and creates a reader-context one; closing the reader tears
+that down too. Any state stored on the plugin class via an event handler is
+only updated while at least one Miniflux instance is registered with
+UIManager. The "Return to Miniflux" flow needs the context to survive across
+those gaps, so we keep it here instead of relying on the broadcast handler.
+--]]
+
+---@class BrowserContextStore
+local BrowserContext = {
+    ---@type MinifluxContext|nil
+    current = nil,
+}
+
+---@param context MinifluxContext|nil
+function BrowserContext.set(context)
+    BrowserContext.current = context
+end
+
+---@return MinifluxContext|nil
+function BrowserContext.get()
+    return BrowserContext.current
+end
+
+return BrowserContext


### PR DESCRIPTION
Closes #65.

## Summary

Follow-up to #62. The merged PR's `returnToBrowser` shipped with two latent bugs that surfaced once we exercised it from multiple contexts. While in there, also unified the duplicated end-of-entry buttons and corrected the macOS dev docs.

## What changed

1. **`refactor(browser): add openContext to seed back stack from saved context`** — moves the `MinifluxContext → view_name` mapping out of the reader module into `MinifluxBrowser:openContext(context)`, which also seeds `self.paths` so the back button is wired correctly.
2. **`fix(reader): wire returnToBrowser through Browser:openContext`** — `MinifluxEndOfBook:returnToBrowser` now delegates to the new helper instead of calling `Browser:navigate` directly (which left `self.paths` empty and dropped the back button).
3. **`feat(reader): unify end-of-entry return buttons into context-aware Return`** — replaces the `⌂ Miniflux folder` button with a single `⌂ Return to Miniflux` button that uses the same helper, so delete-and-return and finish-and-return share one path.
4. **`fix(context): persist browser context outside plugin lifecycle`** — caught during testing. `Miniflux.browser_context` was only updated by an event handler on the plugin instance, but every Miniflux instance is torn down between entry opens, so the second-and-onwards return reused stale context. Moved the canonical state into a tiny module-level store (`shared/browser_context.lua`) written directly by `EntryReader.openEntry`. Broadcast still fires for any future listeners.
5. **`docs(readme): correct macOS plugin path and data dir`** — KOReader on macOS lives in `/Applications/KOReader.app/Contents/koreader/plugins/`, not `~/.config/koreader/`. Updated the dev setup section.
6. **`feat(browser): restore scroll position when returning from an entry`** — `openContext` was seeding the destination view with no `page_state`, so returns always jumped to page 1. Capture `getCurrentItemNumber()` at `openItem` time, stash on `MinifluxContext`, and forward through `navigate()`.

## Acceptance criteria (from #65)

- [x] After deleting an entry, the back button is present and returns the user one level up the natural hierarchy (`feed_entries` → `feeds` → `main`).
- [x] The end-of-entry dialog has a single context-aware return button (no separate `Miniflux folder` button).
- [x] `task check` is clean (stylua, selene, lua-language-server).

## Test plan

Manually tested on macOS KOReader against a live Miniflux instance:

- [x] Open a feed entry → finish → ⌂ Return → lands on that feed's entries with back button → Back → feeds → Back → main.
- [x] Open a category entry → ⌂ Return → lands on that category's entries.
- [x] Open an unread entry → ⌂ Return → lands on the unread list.
- [x] Open a local entry → ⌂ Return → lands on the local list.
- [x] Sequence multiple entries from different contexts (the regression that surfaced the stale-context bug). Each return now lands on the correct view, not the first one's.
- [x] Open an entry from page 3 of a long list → return → list is still scrolled to page 3 with the entry visible.
- [x] Delete a local entry → returns via the same context-aware path with back button intact.