### PR TITLE
Release v0.0.11

### DIFF
--- a/src/_meta.lua
+++ b/src/_meta.lua
@@ -13,7 +13,7 @@ return {
     name = 'miniflux',
     fullname = _('Miniflux'),
     description = _([[Read RSS entries from your Miniflux server.]]),
-    version = '0.0.10',
+    version = '0.0.11',
     author = 'Algus Dark',
     repo_owner = 'AlgusDark',
     repo_name = 'miniflux.koplugin',


### PR DESCRIPTION
Bumps `_meta.lua` to **0.0.11**. When this merges to `main`, the release workflow tags `v0.0.11` and publishes the GitHub release with the built `miniflux.koplugin.zip`.

## Changes since v0.0.10

### Features

- **End-of-entry "Return to Miniflux" button** that lands you back on the saved context (feed, category, unread, local) with the back stack wired up — replaces the old `Miniflux folder` button. (#65, #62)
- **Restored scroll position**: returning from an entry brings you back to the same page in the list instead of jumping to page 1. (#65)

### Fixes

- Back button no longer disappears after returning from an entry. (#65)
- Browser context no longer goes stale across multiple entry opens — the second-and-later return now lands on the correct view, not the first one's. (#65)

### Docs

- README now documents the correct macOS plugin path (`/Applications/KOReader.app/Contents/koreader/plugins/`) and data directory.

### Full commit list

- cf14aac feat(browser): restore scroll position when returning from an entry
- 492aeca docs(readme): correct macOS plugin path and data dir
- 175321d fix(context): persist browser context outside plugin lifecycle
- 801d8ac feat(reader): unify end-of-entry return buttons into context-aware Return
- 612acb4 fix(reader): wire returnToBrowser through Browser:openContext
- 688ce87 refactor(browser): add openContext to seed back stack from saved context
- 8ecc09c added return to browswer functionality upon deleting an entry
- d3c6668 Create LICENSE

## Test plan

- [x] `task check` passes (stylua, selene, lua-language-server).
- [x] Manually tested on macOS KOReader against a live Miniflux instance (see #66 test plan).