### PR TITLE
fix(reader): accept "Z" UTC suffix in iso8601_to_unix

### DIFF
--- a/src/_meta.lua
+++ b/src/_meta.lua
@@ -13,7 +13,7 @@ return {
     name = 'miniflux',
     fullname = _('Miniflux'),
     description = _([[Read RSS entries from your Miniflux server.]]),
-    version = '0.0.11',
+    version = '0.0.12',
     author = 'Algus Dark',
     repo_owner = 'AlgusDark',
     repo_name = 'miniflux.koplugin',

--- a/src/features/reader/services/navigation_service.lua
+++ b/src/features/reader/services/navigation_service.lua
@@ -18,41 +18,42 @@ local PUBLISHED_BEFORE = 'published_before'
 local MSG_FINDING_PREVIOUS = 'Finding previous entry...'
 local MSG_FINDING_NEXT = 'Finding next entry...'
 
+-- Converts an ISO-8601 UTC timestamp (e.g. "2025-09-21T16:43:45Z") to a Unix
+-- timestamp. Miniflux returns published_at in UTC with a "Z" suffix, but
+-- `os.time` always interprets the table as local time, so we compensate by
+-- adding the local timezone offset reported by `os.date("%z")`.
 function iso8601_to_unix(iso_string)
-    local Y, M, D, h, m, sec, sign, tzh, tzm =
-        iso_string:match('(%d+)%-(%d+)%-(%d+)T' .. '(%d+):(%d+):(%d+)' .. '([%+%-])(%d%d):(%d%d)$')
-
-    if not Y then
+    local year, month, day, hour, min, sec =
+        iso_string:match('(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+)Z?')
+    if not year then
         return nil, Error.new(_('Invalid ISO-8601 timestamp format'))
     end
 
-    Y, M, D = tonumber(Y), tonumber(M), tonumber(D)
-    h, m, sec = tonumber(h), tonumber(m), tonumber(sec)
-    tzh, tzm = tonumber(tzh), tonumber(tzm)
+    local utc_time = os.time({
+        year = tonumber(year),
+        month = tonumber(month),
+        day = tonumber(day),
+        hour = tonumber(hour),
+        min = tonumber(min),
+        sec = tonumber(sec),
+    })
 
-    local y = Y
-    local mo = M
-    if mo <= 2 then
-        y = y - 1
-        mo = mo + 12
+    local tz = os.date('%z')
+    if not tz then
+        return utc_time, nil
     end
 
-    local era = math.floor(y / 400)
-    local yoe = y - era * 400
-    local doy = math.floor((153 * (mo - 3) + 2) / 5) + D - 1
-    local doe = yoe * 365 + math.floor(yoe / 4) - math.floor(yoe / 100) + doy
-    local days = era * 146097 + doe - 719468
-
-    local utc_secs = days * 86400 + h * 3600 + m * 60 + sec
-
-    local offs = tzh * 3600 + tzm * 60
-    if sign == '+' then
-        utc_secs = utc_secs - offs
-    else
-        utc_secs = utc_secs + offs
+    local tz_sign, tz_hours, tz_minutes = tz:match('([+-])(%d%d)(%d%d)')
+    if not tz_sign then
+        return utc_time, nil
     end
 
-    return utc_secs, nil
+    local utc_offset = (tonumber(tz_hours) * 3600) + (tonumber(tz_minutes) * 60)
+    if tz_sign == '-' then
+        utc_offset = -utc_offset
+    end
+
+    return utc_time + utc_offset, nil
 end
 
 -- **Navigation Service** - Consolidated navigation utilities including context


### PR DESCRIPTION
## Summary

- Fixes the `Cannot navigate: invalid timestamp format` error reported in #58 when navigating to the previous/next entry.
- The previous regex required an explicit numeric offset (`+HH:MM`/`-HH:MM`), so Miniflux's UTC timestamps like `2025-09-21T16:43:45Z` never matched.
- Replaces the conversion with the calibre-derived implementation suggested in [this comment](https://github.com/AlgusDark/miniflux.koplugin/issues/58#issuecomment-3345363921): build a time with `os.time` and compensate for its local-time interpretation using the offset from `os.date("%z")`.

## Test plan

- [x] Open an entry, reach the end of the article, tap **Next** → navigates to the next entry without the timestamp error.
- [x] Tap **Previous** at the start of an entry → navigates to the previous entry.
- [x] Verify on a device whose local timezone is not UTC (the function compensates via `os.date("%z")`).
- [x] Smoke-test with both cached entries and DocSettings fallback (delete from cache, then navigate).

Closes #58